### PR TITLE
Apply HTML best practices

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     <!-- Fuentes Optimizadas -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&amp;display=swap" rel="stylesheet">
     
     <!-- Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"> 
@@ -575,9 +575,9 @@
                     </div>
                     
                     <!-- Formulario Mailchimp -->
-                    <div id="mc_embed_signup">
-                        <form action="https://orangevapor.us17.list-manage.com/subscribe/post?u=386ca740d7cf02ec261f47f33&amp;id=5a55144e86&amp;f_id=0090eee3f0" method="post" id="mc-embedded-subscribe-form-contact" name="mc-embedded-subscribe-form" class="validate" target="_blank" rel="noopener noreferrer">
-                            <div id="mc_embed_signup_scroll">
+                    <div id="mc_embed_signup_contact">
+                        <form action="https://orangevapor.us17.list-manage.com/subscribe/post?u=386ca740d7cf02ec261f47f33&amp;id=5a55144e86&amp;f_id=0090eee3f0" method="post" id="mc-embedded-subscribe-form-contact" name="mc-embedded-subscribe-form-contact" class="validate" target="_blank" rel="noopener noreferrer">
+                            <div id="mc_embed_signup_scroll_contact">
                                 <div class="indicates-required"><span class="asterisk">*</span> indica que es obligatorio</div>
                                 <div class="mc-field-group">
                                     <label for="mce-EMAIL-contact">Dirección de correo electrónico <span class="asterisk">*</span></label>

--- a/index.html
+++ b/index.html
@@ -111,9 +111,9 @@
                     <!-- Social Proof Minimalista -->
                     <div class="social-proof">
                         <div class="proof-avatars">
-                            <img src="https://randomuser.me/api/portraits/men/32.jpg" alt="Cliente">
-                            <img src="https://randomuser.me/api/portraits/women/44.jpg" alt="Cliente">
-                            <img src="https://randomuser.me/api/portraits/men/18.jpg" alt="Cliente">
+                            <img src="https://randomuser.me/api/portraits/men/32.jpg" alt="Foto de cliente satisfecho" loading="lazy">
+                            <img src="https://randomuser.me/api/portraits/women/44.jpg" alt="Foto de cliente satisfecho" loading="lazy">
+                            <img src="https://randomuser.me/api/portraits/men/18.jpg" alt="Foto de cliente satisfecho" loading="lazy">
                             <span class="proof-more">+44</span>
                         </div>
                         <p class="proof-text">emprendedores ya no pierden tiempo en marketing</p>
@@ -134,7 +134,7 @@
                         
                         <!-- Formulario Mailchimp -->
                         <div id="mc_embed_signup">
-                            <form action="https://orangevapor.us17.list-manage.com/subscribe/post?u=386ca740d7cf02ec261f47f33&amp;id=5a55144e86&amp;f_id=0090eee3f0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank">
+                            <form action="https://orangevapor.us17.list-manage.com/subscribe/post?u=386ca740d7cf02ec261f47f33&amp;id=5a55144e86&amp;f_id=0090eee3f0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" rel="noopener noreferrer">
                                 <div id="mc_embed_signup_scroll">
                                     <div class="mc-field-group">
                                         <label for="mce-EMAIL">Email <span class="asterisk">*</span></label>
@@ -146,7 +146,7 @@
                                     </div>
                                     <div class="mc-field-group">
                                         <label for="mce-PHONE">WhatsApp <span class="asterisk">*</span></label>
-                                        <input type="text" name="PHONE" class="REQ_CSS" id="mce-PHONE" value="">
+                                        <input type="tel" name="PHONE" class="REQ_CSS" id="mce-PHONE" required value="">
                                     </div>
                                     <div class="mc-field-group">
                                         <label for="mce-COMPANY">Empresa</label>
@@ -365,7 +365,7 @@
                             Ahora uso ese tiempo para abrir mi segunda sucursal."
                         </p>
                         <div class="testimonial-author">
-                            <img src="https://randomuser.me/api/portraits/women/44.jpg" alt="María">
+                            <img src="https://randomuser.me/api/portraits/women/44.jpg" alt="Foto de María, emprendedora" loading="lazy">
                             <div>
                                 <strong>María G.</strong>
                                 <span>Dueña de cafetería</span>
@@ -576,7 +576,7 @@
                     
                     <!-- Formulario Mailchimp -->
                     <div id="mc_embed_signup">
-                        <form action="https://orangevapor.us17.list-manage.com/subscribe/post?u=386ca740d7cf02ec261f47f33&amp;id=5a55144e86&amp;f_id=0090eee3f0" method="post" id="mc-embedded-subscribe-form-contact" name="mc-embedded-subscribe-form" class="validate" target="_blank">
+                        <form action="https://orangevapor.us17.list-manage.com/subscribe/post?u=386ca740d7cf02ec261f47f33&amp;id=5a55144e86&amp;f_id=0090eee3f0" method="post" id="mc-embedded-subscribe-form-contact" name="mc-embedded-subscribe-form" class="validate" target="_blank" rel="noopener noreferrer">
                             <div id="mc_embed_signup_scroll">
                                 <div class="indicates-required"><span class="asterisk">*</span> indica que es obligatorio</div>
                                 <div class="mc-field-group">
@@ -589,7 +589,7 @@
                                 </div>
                                 <div class="mc-field-group">
                                     <label for="mce-PHONE-contact">Número de WhatsApp <span class="asterisk">*</span></label>
-                                    <input type="text" name="PHONE" class="REQ_CSS" id="mce-PHONE-contact" value="">
+                                    <input type="tel" name="PHONE" class="REQ_CSS" id="mce-PHONE-contact" required value="">
                                 </div>
                                 <div class="mc-field-group">
                                     <label for="mce-COMPANY-contact">Empresa </label>
@@ -672,7 +672,7 @@
                         </div>
                         <p>"La auditoría detectó errores que me costaban $850 por semana. Mi ROAS aumentó un 187% en solo 14 días."</p>
                         <div class="mini-author">
-                            <img src="https://randomuser.me/api/portraits/men/45.jpg" alt="Testimonio">
+                            <img src="https://randomuser.me/api/portraits/men/45.jpg" alt="Foto de cliente satisfecho" loading="lazy">
                             <div>
                                 <span class="name">Carlos L.</span>
                                 <span class="business">Tienda de decoración</span>
@@ -750,7 +750,7 @@
     </div>
 
     <!-- Scripts -->
-    <script src="script-rediseno.js"></script>
+    <script src="script-rediseno.js" defer></script>
 
 
 </body>


### PR DESCRIPTION
## Summary
- add security attribute on mailchimp forms
- use `type="tel"` and `required` for WhatsApp fields
- lazy-load testimonial images and provide descriptive alt text
- defer JavaScript to avoid blocking rendering

## Testing
- `tidy -q -e index.html`

------
https://chatgpt.com/codex/tasks/task_e_683f8ac59fa0832c8f37227df3c3436c