### PR TITLE
Adjust CTA and audit colors

### DIFF
--- a/contacto.css
+++ b/contacto.css
@@ -412,15 +412,14 @@
 }
 
 .cta-content .btn {
-    background-color: var(--blanco);
-    color: var(--naranja-principal);
+    background: linear-gradient(135deg, var(--naranja-principal), var(--naranja-secundario));
+    color: var(--blanco);
     border: none;
 }
 
 .cta-content .btn:hover {
-    background-color: #F9F9F9;
     transform: translateY(-3px);
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 10px 30px rgba(255, 107, 53, 0.4);
 }
 
 .cta-content .btn::before {

--- a/style-rediseno.css
+++ b/style-rediseno.css
@@ -321,7 +321,7 @@ a {
 }
 
 .btn-nav {
-    background: var(--verde-gradient);
+    background: var(--naranja-gradient);
     color: var(--blanco);
     padding: 14px 28px;
     border-radius: var(--radio-full);
@@ -349,7 +349,7 @@ a {
 
 .btn-nav:hover {
     transform: translateY(-3px);
-    box-shadow: var(--sombra-verde-glow);
+    box-shadow: var(--sombra-glow);
 }
 
 /* ==========================================================================
@@ -1327,7 +1327,7 @@ a {
 }
 
 .btn-success {
-    background: var(--verde-gradient);
+    background: var(--naranja-gradient);
     color: var(--blanco);
     padding: 16px 32px;
     border-radius: var(--radio-full);
@@ -1341,7 +1341,7 @@ a {
 
 .btn-success:hover {
     transform: translateY(-3px);
-    box-shadow: var(--sombra-verde-glow);
+    box-shadow: var(--sombra-glow);
 }
 
 .outcome-warning {
@@ -1925,8 +1925,8 @@ a {
     display: inline-flex;
     align-items: center;
     gap: var(--espacio-2);
-    background: var(--blanco);
-    color: var(--naranja);
+    background: var(--naranja-gradient);
+    color: var(--blanco);
     padding: 24px 48px;
     border-radius: var(--radio-full);
     font-size: var(--texto-2xl);
@@ -1954,7 +1954,7 @@ a {
 
 .btn-final:hover {
     transform: translateY(-6px) scale(1.05);
-    box-shadow: var(--sombra-xl), 0 0 50px rgba(255,255,255,0.5);
+    box-shadow: var(--sombra-xl), var(--sombra-glow), 0 0 50px rgba(255,255,255,0.5);
 }
 
 .cta-disclaimer {

--- a/tuauditoriagratis.html
+++ b/tuauditoriagratis.html
@@ -170,7 +170,7 @@
         }
 
         .cta-badge {
-            background: var(--naranja-gradient);
+            background: var(--success-green);
             color: var(--white);
             padding: 0.75rem 1.5rem;
             border-radius: var(--radius-full);
@@ -189,8 +189,8 @@
         }
 
         @keyframes glow {
-            from { box-shadow: 0 0 5px var(--naranja-principal); }
-            to { box-shadow: 0 0 20px var(--naranja-principal), 0 0 30px var(--naranja-principal); }
+            from { box-shadow: 0 0 5px var(--success-green); }
+            to { box-shadow: 0 0 20px var(--success-green), 0 0 30px var(--success-green); }
         }
 
         /* Hero Section */
@@ -554,8 +554,8 @@
             display: inline-flex;
             align-items: center;
             gap: 0.75rem;
-            background: var(--white);
-            color: var(--naranja-principal);
+            background: var(--naranja-gradient);
+            color: var(--white);
             padding: 1.25rem 3rem;
             border-radius: var(--radius-lg);
             font-family: var(--font-primary);


### PR DESCRIPTION
## Summary
- set nav button and other CTAs to OrangeVapor orange
- style success and final buttons in orange gradient
- keep WhatsApp CTA green but turn audit badge green
- style contact page CTAs with orange gradient

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f94033010832cb313fb7a22f4f9f1