### PR TITLE
Fix icon for error item and adjust service badge

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,7 +244,7 @@
                 <!-- Error 3 -->
                 <div class="problem-card">
                     <div class="problem-icon">
-                        <i class="fas fa-chart-down"></i>
+                        <i class="fas fa-arrow-trend-down"></i>
                     </div>
                     <h3>Resultados amateur = pérdidas</h3>
                     <p>Sin experiencia, tus campañas cuestan 3x más y venden 70% menos.</p>

--- a/style-rediseno.css
+++ b/style-rediseno.css
@@ -1426,6 +1426,10 @@ a {
     color: var(--blanco);
 }
 
+.service-card.complete {
+    overflow: visible;
+}
+
 .service-header h3 {
     font-size: var(--texto-xl);
     margin-bottom: 4px;


### PR DESCRIPTION
## Summary
- add missing icon for "Resultados amateur = pérdidas"
- ensure "Máxima libertad" badge isn't cut off for Marketing Completo service

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68406843aba8832cbc5a2f5d22ddde27