### PR TITLE
Improve dark mode overlay contrast

### DIFF
--- a/style-rediseno.css
+++ b/style-rediseno.css
@@ -43,6 +43,8 @@
   --blanco: #ffffff;
   --blanco-glass: rgba(255, 255, 255, 0.1);
   --blanco-glass-strong: rgba(255, 255, 255, 0.2);
+  --overlay-bg: rgba(255, 255, 255, 0.95);
+  --glass-heavy: rgba(255, 255, 255, 0.9);
 
   /* Espaciado fluido con clamp() */
   --espacio-1: clamp(6px, 1vw, 8px);
@@ -454,7 +456,7 @@ a {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(255, 255, 255, 0.95);
+  background: var(--overlay-bg);
   backdrop-filter: blur(1px);
 }
 
@@ -1142,7 +1144,7 @@ a {
   background: linear-gradient(
     135deg,
     rgba(255, 107, 53, 0.02) 0%,
-    rgba(255, 255, 255, 0.95) 50%,
+    var(--overlay-bg) 50%,
     rgba(0, 200, 83, 0.02) 100%
   );
   position: relative;
@@ -1657,7 +1659,7 @@ a {
 }
 
 .guarantee-box {
-  background: rgba(255, 255, 255, 0.9);
+  background: var(--glass-heavy);
   backdrop-filter: blur(20px);
   border: 2px dashed var(--verde-exito);
   border-radius: var(--radio-lg);
@@ -1694,7 +1696,7 @@ a {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(255, 255, 255, 0.95);
+  background: var(--overlay-bg);
   backdrop-filter: blur(1px);
 }
 
@@ -2080,7 +2082,7 @@ a {
 }
 
 .mini-testimonial {
-  background: rgba(255, 255, 255, 0.9);
+  background: var(--glass-heavy);
   backdrop-filter: blur(20px);
   border-radius: var(--radio-lg);
   padding: var(--espacio-5);
@@ -2623,6 +2625,8 @@ body.dark-mode {
   --blanco: #ffffff;
   --blanco-glass: rgba(255, 255, 255, 0.1);
   --blanco-glass-strong: rgba(255, 255, 255, 0.2);
+  --overlay-bg: rgba(0, 0, 0, 0.7);
+  --glass-heavy: rgba(0, 0, 0, 0.6);
   background: var(--gris-ultra-claro);
   color: var(--negro);
 }


### PR DESCRIPTION
## Summary
- add new overlay variables for light and dark mode
- use the new variables on hero, solution and blog overlays
- darken guarantee boxes and mini testimonials in dark mode

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68438230823c832ca5ebe62aff188199