### PR TITLE
Improve brochure page styling

### DIFF
--- a/brochure.html
+++ b/brochure.html
@@ -4,7 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Orange Vapor - Servicios de Marketing Digital</title>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700;800&family=Open+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <!-- Fuentes unificadas con el resto del sitio -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <style>
         @page {
@@ -14,10 +17,11 @@
         
         :root {
             /* Paleta de colores principal */
-            --naranja-principal: #FF7200;
-            --naranja-secundario: #FF9340;
-            --naranja-claro: #FFF1E6;
-            --naranja-oscuro: #E56700;
+            /* Colores acorde al rediseño del sitio */
+            --naranja-principal: #ff6b35;
+            --naranja-secundario: #ff8a50;
+            --naranja-claro: #fff3e0;
+            --naranja-oscuro: #ff5722;
             
             /* Colores complementarios */
             --blanco: #FFFFFF;
@@ -43,8 +47,8 @@
             --auditoria-verde-hover: #276749;
 
             /* Fuentes */
-            --fuente-principal: 'Montserrat', sans-serif;
-            --fuente-secundaria: 'Open Sans', sans-serif;
+            --fuente-principal: 'Inter', sans-serif;
+            --fuente-secundaria: 'Inter', sans-serif;
         }
 
         /* Reset */
@@ -102,7 +106,7 @@
             
             /* Establecer colores explícitos para la portada */
             .cover {
-                background-color: #FF7200 !important;
+                background-color: #ff6b35 !important;
                 color: white !important;
             }
             
@@ -113,7 +117,7 @@
                 left: 0;
                 width: 100%;
                 height: 100%;
-                background-color: #FF7200 !important;
+                background-color: #ff6b35 !important;
                 z-index: -1;
             }
             
@@ -136,11 +140,11 @@
             
             /* Fondos de color para secciones especiales */
             .package-section {
-                background-color: #FFF1E6 !important;
+                background-color: #fff3e0 !important;
             }
             
             .package-badge {
-                background-color: #FF7200 !important;
+                background-color: #ff6b35 !important;
                 color: white !important;
             }
             
@@ -149,7 +153,7 @@
             }
             
             .contact-cta {
-                background-color: #FF7200 !important;
+                background-color: #ff6b35 !important;
                 color: white !important;
             }
             


### PR DESCRIPTION
## Summary
- use same Inter font as the homepage
- update main color variables to match the redesign
- adjust printed color rules with new palette

## Testing
- `tidy -q -e brochure.html`

------
https://chatgpt.com/codex/tasks/task_e_685d6d041870832c90e8783a390a3ed2