### PR TITLE
Update brochure to remove free audit info

### DIFF
--- a/brochure.html
+++ b/brochure.html
@@ -498,11 +498,9 @@
             background: linear-gradient(45deg, #833AB4, #E1306C);
         }
 
-        .service-express .service-icon-wrapper {
             background: linear-gradient(135deg, #FF1744, #D50000);
         }
 
-        .service-audit .service-icon-wrapper {
             background: linear-gradient(135deg, #00C853, #00A040);
         }
 
@@ -614,112 +612,6 @@
             color: var(--gris-texto);
         }
 
-        /* Card especial de auditoría */
-        .audit-card {
-            background: linear-gradient(135deg, var(--audit-green) 0%, #00A040 100%);
-            color: white;
-            position: relative;
-            overflow: hidden;
-        }
-
-        .audit-card .service-card-header {
-            background: rgba(255,255,255,0.1);
-        }
-
-        .audit-card .service-name,
-        .audit-card .service-tagline,
-        .audit-card .service-description,
-        .audit-card .service-features-title {
-            color: white;
-        }
-
-        .audit-card .feature-item {
-            color: rgba(255,255,255,0.9);
-        }
-
-        .audit-card .feature-icon {
-            color: white;
-        }
-
-        .audit-card .service-pricing {
-            border-top-color: rgba(255,255,255,0.2);
-        }
-
-        .audit-badge {
-            position: absolute;
-            top: 20px;
-            right: 20px;
-            background: white;
-            color: var(--audit-green);
-            padding: 10px 24px;
-            border-radius: 30px;
-            font-weight: 800;
-            font-size: 16px;
-            box-shadow: var(--sombra-media);
-        }
-
-        /* Servicio Express mejorado */
-        .express-section {
-            background: var(--gris-claro);
-            position: relative;
-            overflow: hidden;
-        }
-
-        .express-card {
-            background: linear-gradient(135deg, var(--express-red) 0%, #D50000 100%);
-            color: white;
-            border-radius: 20px;
-            padding: 40px;
-            position: relative;
-            overflow: hidden;
-            box-shadow: var(--sombra-fuerte);
-        }
-
-        .express-card::before {
-            content: '';
-            position: absolute;
-            top: -50%;
-            right: -20%;
-            width: 300px;
-            height: 300px;
-            background: rgba(255,255,255,0.1);
-            border-radius: 50%;
-        }
-
-        .express-content {
-            position: relative;
-            z-index: 1;
-        }
-
-        .express-header {
-            display: flex;
-            align-items: center;
-            gap: 20px;
-            margin-bottom: 30px;
-        }
-
-        .express-icon {
-            width: 80px;
-            height: 80px;
-            background: rgba(255,255,255,0.2);
-            border-radius: 20px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-size: 32px;
-        }
-
-        .express-text h3 {
-            font-family: var(--fuente-titulos);
-            font-size: 28px;
-            font-weight: 800;
-            margin-bottom: 5px;
-        }
-
-        .express-text p {
-            font-size: 18px;
-            opacity: 0.9;
-        }
 
         /* Paquete completo mejorado */
         .package-section {
@@ -1353,9 +1245,7 @@
                     </div>
                 </div>
 
-                <a href="#contacto" class="hero-cta">
-                    Auditoría GRATIS de tus campañas
-                </a>
+                <a href="#contacto" class="hero-cta">Solicitá tu diagnóstico sin cargo</a>
             </div>
         </section>
 
@@ -1402,46 +1292,6 @@
                 </div>
 
                 <div class="services-grid">
-                    <!-- Auditoría GRATIS -->
-                    <div class="service-card audit-card">
-                        <div class="audit-badge">GRATIS</div>
-                        <div class="service-card-header">
-                            <div class="service-icon-wrapper">
-                                <i class="fas fa-search-dollar"></i>
-                            </div>
-                            <div class="service-header-text">
-                                <h3 class="service-name">Auditoría Profesional</h3>
-                                <p class="service-tagline">Descubrí dónde perdés dinero</p>
-                            </div>
-                        </div>
-                        <div class="service-card-body">
-                            <p class="service-description">
-                                En 24-48 horas, analizamos tus campañas y te mostramos exactamente dónde estás perdiendo presupuesto. Sin compromisos, sin costos ocultos.
-                            </p>
-                            <div class="service-features">
-                                <p class="service-features-title">Incluye:</p>
-                                <div class="feature-item">
-                                    <i class="fas fa-check feature-icon"></i>
-                                    <span>Análisis completo con capturas de pantalla de errores críticos</span>
-                                </div>
-                                <div class="feature-item">
-                                    <i class="fas fa-check feature-icon"></i>
-                                    <span>Comparativa con tu competencia y sus anuncios exitosos</span>
-                                </div>
-                                <div class="feature-item">
-                                    <i class="fas fa-check feature-icon"></i>
-                                    <span>Plan de acción concreto entregado en PDF profesional</span>
-                                </div>
-                            </div>
-                            <div class="service-pricing">
-                                <div class="pricing-main">
-                                    <span class="price">GRATIS</span>
-                                </div>
-                                <span style="color: white; font-size: 16px;">Valor real: US$199</span>
-                            </div>
-                        </div>
-                    </div>
-
                     <!-- Meta Ads -->
                     <div class="service-card service-meta">
                         <div class="service-card-header">
@@ -1660,53 +1510,6 @@
             </div>
         </section>
 
-        <!-- Servicio Express -->
-        <section class="section express-section">
-            <div class="content-wrapper">
-                <div class="section-header">
-                    <h2 class="section-title">¿Necesitás resultados YA?</h2>
-                    <p class="section-subtitle">Optimización Express: mejorá tus campañas en solo 48 horas</p>
-                </div>
-
-                <div class="express-card">
-                    <div class="express-content">
-                        <div class="express-header">
-                            <div class="express-icon">
-                                <i class="fas fa-bolt"></i>
-                            </div>
-                            <div class="express-text">
-                                <h3>Optimización Express</h3>
-                                <p>Rescatamos tus campañas en 48 horas</p>
-                            </div>
-                        </div>
-                        <p style="font-size: 18px; margin-bottom: 25px; line-height: 1.6; opacity: 0.9;">
-                            La semana pasada, una tienda online descubrió que el 63% de su presupuesto se desperdiciaba en una configuración incorrecta. En solo 48 horas, aplicamos nuestro sistema de Detección de Fugas™ y transformamos ese desperdicio en ventas reales.
-                        </p>
-                        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 20px; margin-bottom: 30px;">
-                            <div style="display: flex; align-items: center; gap: 15px;">
-                                <i class="fas fa-check" style="color: white; font-size: 18px;"></i>
-                                <span>Análisis profundo y corrección de errores críticos</span>
-                            </div>
-                            <div style="display: flex; align-items: center; gap: 15px;">
-                                <i class="fas fa-check" style="color: white; font-size: 18px;"></i>
-                                <span>Nueva estrategia basada en datos reales de tu negocio</span>
-                            </div>
-                            <div style="display: flex; align-items: center; gap: 15px;">
-                                <i class="fas fa-check" style="color: white; font-size: 18px;"></i>
-                                <span>Pack completo de anuncios optimizados listos para usar</span>
-                            </div>
-                        </div>
-                        <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 20px;">
-                            <div>
-                                <span style="font-family: var(--fuente-titulos); font-size: 36px; font-weight: 800;">US$299</span>
-                                <span style="font-size: 18px; margin-left: 10px; opacity: 0.8;">único pago</span>
-                            </div>
-                            <span style="font-size: 16px; opacity: 0.8;">Implementación inmediata</span>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </section>
 
         <!-- Paquete Completo -->
         <section class="section package-section">
@@ -1714,7 +1517,7 @@
             <div class="content-wrapper">
                 <div class="package-content">
                     <div class="package-header">
-                        <span class="package-badge">AHORRÁ US$196 POR MES</span>
+                        <span class="package-badge">AHORRÁ US$496 POR MES</span>
                         <h2 class="package-title">Paquete Marketing Completo</h2>
                         <p class="package-subtitle">Todo lo que necesitás para dejar de preocuparte por el marketing</p>
                     </div>
@@ -1772,7 +1575,7 @@
                             <div class="package-original-price">US$1,495 /mes</div>
                             <div class="package-price">US$999</div>
                             <div class="package-price-period">por mes</div>
-                            <div class="package-save">Ahorrás US$196 mensual</div>
+                            <div class="package-save">Ahorrás US$496 mensual</div>
                             <p style="margin-top: 25px; font-size: 16px; color: var(--gris-texto); line-height: 1.5;">
                                 Setup bonificado • Sin contratos largos<br>
                                 Pagá en USD o ARS al cambio oficial
@@ -1788,7 +1591,7 @@
             <div class="content-wrapper">
                 <div class="section-header">
                     <h2 class="section-title">Empezá hoy, sin complicaciones</h2>
-                    <p class="section-subtitle">Desde la auditoría hasta ver resultados, todo es simple y transparente</p>
+                    <p class="section-subtitle">Desde el diagnóstico inicial hasta ver resultados, todo es simple y transparente</p>
                 </div>
 
                 <div class="process-steps">
@@ -1796,7 +1599,7 @@
                         <div class="step-icon">
                             <span class="step-number">1</span>
                         </div>
-                        <h3 class="step-title">Auditoría GRATIS</h3>
+                        <h3 class="step-title">Diagnóstico inicial</h3>
                         <p class="step-description">
                             Completás un formulario simple. En 24-48hs recibís un diagnóstico profesional sin costo.
                         </p>
@@ -1942,10 +1745,10 @@
                     </div>
                 </div>
                 <p class="cta-highlight">
-                    Pedí tu auditoría GRATIS hoy
+                    Solicitá tu diagnóstico sin cargo
                 </p>
                 <p class="cta-details">
-                    Sin compromiso • Resultados en 24-48hs • 100% profesional
+                    Sin compromiso • Respuesta en 24hs • 100% profesional
                 </p>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- clean up brochure layout
- remove free audit and express sections
- show correct $496 savings in package deal
- tweak CTA text for diagnosis offer

## Testing
- `htmlhint brochure.html`

------
https://chatgpt.com/codex/tasks/task_e_685da4522088832c8c86dc2a821e6f7b