### PR TITLE
Update Fabuladores style

### DIFF
--- a/fabuladores/index.html
+++ b/fabuladores/index.html
@@ -9,10 +9,10 @@
     <!-- Preload crítico -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Merriweather:wght@700;900&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Poppins:wght@400;600;700;800&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
     
     <!-- Fallback para fonts -->
-    <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Merriweather:wght@700;900&display=swap"></noscript>
+    <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Poppins:wght@400;600;700;800&display=swap"></noscript>
     
     <!-- Meta tags sociales -->
     <meta property="og:title" content="720 Formas de Narrar - Curso de Técnicas Narrativas">

--- a/fabuladores/styles.css
+++ b/fabuladores/styles.css
@@ -6,6 +6,7 @@
 --primary-blue: #2563eb;
             --success-green: #10b981;
             --accent-orange: #f59e0b;
+            --accent-orange-dark: #d97706;
             --text-dark: #1f2937;
             --bg-light: #f9fafb;
    
@@ -36,8 +37,8 @@
   --shadow-inner: inset 0 2px 4px 0 rgba(0, 0, 0, 0.06);
   
   /* Tipografía optimizada */
-  --font-primary: 'Poppins', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  --font-secondary: 'Merriweather', Georgia, serif;
+  --font-primary: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-secondary: 'Poppins', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   
   /* Espaciado */
   --spacing-xs: 0.5rem;
@@ -85,6 +86,7 @@ html {
 
 body {
   font-family: var(--font-primary);
+  font-size: 1.125rem;
   line-height: 1.6;
   color: var(--text-dark);
   background-color: var(--bg-cream);
@@ -449,7 +451,7 @@ strong {
   display: block;
   font-size: 2rem;
   font-weight: 700;
-  color: var(--primary-pink);
+  color: var(--accent-orange);
   line-height: 1;
 }
 
@@ -474,13 +476,14 @@ strong {
   display: inline-flex;
   flex-direction: column;
   align-items: center;
-  background: linear-gradient(135deg, var(--primary-pink) 0%, var(--primary-pink-dark) 100%);
+  background: linear-gradient(135deg, var(--accent-orange) 0%, var(--accent-orange-dark) 100%);
   color: white;
   padding: 1.25rem 3rem;
   border-radius: var(--radius-full);
-  font-weight: 700;
+  font-family: var(--font-secondary);
+  font-weight: 600;
   transition: all var(--transition-normal);
-  box-shadow: 0 10px 30px rgba(199, 101, 140, 0.3);
+  box-shadow: 0 10px 30px rgba(245, 158, 11, 0.3);
   position: relative;
   overflow: hidden;
 }
@@ -502,7 +505,7 @@ strong {
 
 .btn-primary:hover {
   transform: translateY(-3px);
-  box-shadow: 0 15px 40px rgba(199, 101, 140, 0.4);
+  box-shadow: 0 15px 40px rgba(245, 158, 11, 0.4);
 }
 
 .btn-main {
@@ -788,7 +791,7 @@ strong {
   left: 0;
   width: 100%;
   height: 4px;
-  background: linear-gradient(90deg, var(--primary-blue) 0%, var(--primary-pink) 100%);
+  background: linear-gradient(90deg, var(--primary-blue) 0%, var(--accent-orange) 100%);
   transform: scaleX(0);
   transform-origin: left;
   transition: transform var(--transition-normal);
@@ -805,7 +808,7 @@ strong {
 
 .benefit-card.featured {
   background: linear-gradient(135deg, var(--bg-white) 0%, rgba(199, 101, 140, 0.05) 100%);
-  border-color: var(--primary-pink);
+  border-color: var(--accent-orange);
 }
 
 .featured-badge {
@@ -988,6 +991,7 @@ strong {
   color: white;
   padding: 1rem 2rem;
   border-radius: var(--radius-full);
+  font-family: var(--font-secondary);
   font-weight: 600;
   transition: all var(--transition-normal);
   box-shadow: var(--shadow-md);
@@ -1028,7 +1032,7 @@ strong {
 }
 
 .module-card.featured {
-  border-color: var(--primary-pink);
+  border-color: var(--accent-orange);
   background: linear-gradient(to bottom, var(--bg-white) 0%, rgba(246, 53, 114, 0.02) 100%);
 }
 
@@ -1040,7 +1044,7 @@ strong {
 
 .module-number {
   display: inline-block;
-  background: var(--primary-pink);
+  background: var(--accent-orange);
   color: white;
   padding: 0.25rem 0.75rem;
   border-radius: var(--radius-full);
@@ -1149,7 +1153,7 @@ strong {
   font-family: var(--font-secondary);
   font-size: 2rem;
   font-weight: 700;
-  color: var(--primary-pink);
+  color: var(--accent-orange);
   margin-bottom: 0.5rem;
 }
 
@@ -1215,7 +1219,7 @@ strong {
   background: var(--bg-cream);
   padding: var(--spacing-lg);
   border-radius: var(--radius-lg);
-  border-left: 4px solid var(--primary-pink);
+  border-left: 4px solid var(--accent-orange);
 }
 
 .instructor-quote blockquote {
@@ -1374,7 +1378,7 @@ strong {
   display: block;
   font-size: 2.5rem;
   font-weight: 900;
-  color: var(--primary-pink);
+  color: var(--accent-orange);
   line-height: 1;
   margin-bottom: 0.5rem;
 }
@@ -1481,7 +1485,7 @@ input:checked + .slider:before {
 }
 
 .pricing-card.featured {
-  border-color: var(--primary-pink);
+  border-color: var(--accent-orange);
   transform: scale(1.05);
   box-shadow: var(--shadow-2xl);
 }
@@ -1539,7 +1543,7 @@ input:checked + .slider:before {
 .price-amount {
   font-size: 3.5rem;
   font-weight: 900;
-  color: var(--primary-pink);
+  color: var(--accent-orange);
   line-height: 1;
 }
 
@@ -1605,7 +1609,7 @@ input:checked + .slider:before {
 }
 
 .star-icon {
-  color: var(--primary-pink);
+  color: var(--accent-orange);
 }
 
 .plan-cta {
@@ -1942,7 +1946,7 @@ input:checked + .slider:before {
   display: block;
   font-size: 3rem;
   font-weight: 900;
-  color: var(--primary-pink);
+  color: var(--accent-orange);
   line-height: 1;
   text-shadow: 0 0 20px rgba(199, 101, 140, 0.5);
 }
@@ -1968,7 +1972,8 @@ input:checked + .slider:before {
   align-items: center;
   padding: 1.25rem 2.5rem;
   border-radius: var(--radius-full);
-  font-weight: 700;
+  font-family: var(--font-secondary);
+  font-weight: 600;
   transition: all var(--transition-normal);
   position: relative;
   min-width: 200px;
@@ -1988,12 +1993,12 @@ input:checked + .slider:before {
 .btn-cta.ultra {
   background: linear-gradient(135deg, var(--accent-orange) 0%, var(--accent-orange-dark) 100%);
   color: white;
-  box-shadow: 0 10px 30px rgba(255, 107, 53, 0.5);
+  box-shadow: 0 10px 30px rgba(245, 158, 11, 0.5);
 }
 
 .btn-cta.ultra:hover {
   transform: translateY(-3px) scale(1.05);
-  box-shadow: 0 15px 40px rgba(255, 107, 53, 0.6);
+  box-shadow: 0 15px 40px rgba(245, 158, 11, 0.6);
 }
 
 .btn-plan-name {
@@ -2071,7 +2076,7 @@ input:checked + .slider:before {
 
 .footer-tagline {
   font-size: 1rem;
-  color: var(--primary-pink);
+  color: var(--accent-orange);
   font-style: italic;
   margin-bottom: var(--spacing-sm);
 }
@@ -2602,9 +2607,10 @@ textarea:focus {
 /* High contrast mode */
 @media (prefers-contrast: high) {
   :root {
-    --primary-pink: #D7719C;
-    --accent-orange: #ff5500;
-    --primary-blue: #0066ff;
+    --accent-orange: #f59e0b;
+    --accent-orange-dark: #b45309;
+    --primary-blue: #2563eb;
+    --success-green: #10b981;
     --text-dark: #000000;
     --text-medium: #333333;
     --bg-cream: #ffffff;


### PR DESCRIPTION
## Summary
- adjust color variables for blue, green and orange palette
- switch fonts to Inter for body and Poppins for headings
- style buttons and CTAs with new accent color
- include Poppins font in HTML preload

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68690eaf2a70832cb9076f7124aa7139