### PR TITLE
Update Fabuladores landing

### DIFF
--- a/fabuladores/index.html
+++ b/fabuladores/index.html
@@ -68,17 +68,17 @@
     <header class="header" id="header">
         <div class="container">
             <div class="header-content">
-                <a href="https://fabuladores.com" class="logo">
+                <div class="logo">
                     <span class="logo-text">Fabuladores</span>
-                    <span class="logo-tagline">Escuela de Narrativa</span>
-                </a>
+                    <span class="logo-tagline">Zona de Exploración Narrativa</span>
+                </div>
                 <div class="header-actions">
                     <div class="header-trust">
                         <span class="trust-item">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
                                 <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
                             </svg>
-                            Garantía 30 días
+                            Mira un extracto de la clase 2 gratis
                         </span>
                         <span class="trust-item">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
@@ -107,15 +107,7 @@
                         <span>📚 El curso de narrativa más completo en español</span>
                     </div>
                     
-                    <h1 class="hero-title">
-                        Deja el <span class="strike-through">"había una vez"</span><br>
-                        para los novatos
-                    </h1>
-                    
-                    <p class="hero-subtitle">
-                        Descubre <strong>720 formas de narrar</strong> y aprende a escribir con la precisión de Borges 
-                        y la potencia emocional de Rulfo.
-                    </p>
+                    <h1 class="hero-title">Transforma tu manera de narrar</h1>
                     
                     <!-- Social Proof mejorado -->
                     <div class="social-proof-hero">
@@ -168,7 +160,7 @@
                     <!-- CTA Principal mejorado -->
                     <div class="hero-cta">
                         <a href="#planes" class="btn-primary">
-                            <span class="btn-main">Quiero dominar la narrativa</span>
+                            <span class="btn-main">Potencia tu narrativa</span>
                             <span class="btn-sub">Acceso inmediato • 30% de descuento</span>
                         </a>
                         <div class="payment-methods">
@@ -242,7 +234,6 @@
                 <img src="https://fabuladores.com/wp-content/uploads/2025/06/curso-720.cover_.inv_.nobck_.4.png" alt="720 Formas de Narrar - Logo del Curso" class="course-badge-image">
                 <div class="badge-text">
                     <h2 class="badge-title">El curso más completo de técnicas narrativas</h2>
-                    <p class="badge-subtitle">Un método probado que ha transformado a más de 375 escritores</p>
                 </div>
             </div>
         </div>
@@ -264,10 +255,6 @@
                 <div class="problem-card">
                     <span class="problem-icon">📝</span>
                     <p class="problem-text">Tus textos <strong>no enganchan</strong> como quieres</p>
-                </div>
-                <div class="problem-card">
-                    <span class="problem-icon">🎭</span>
-                    <p class="problem-text">Te falta técnica para <strong>crear personajes memorables</strong></p>
                 </div>
             </div>
             
@@ -863,7 +850,7 @@
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
                                 <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4z"/>
                             </svg>
-                            Garantía de 30 días
+                            Mira un extracto de la clase 2 gratis
                         </p>
                     </div>
                 </div>
@@ -936,7 +923,7 @@
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
                                 <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4z"/>
                             </svg>
-                            Garantía de 30 días
+                            Mira un extracto de la clase 2 gratis
                         </p>
                     </div>
                 </div>
@@ -1205,7 +1192,7 @@
                         <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                             <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4z"/>
                         </svg>
-                        <span>Garantía 30 días</span>
+                        <span>Mira un extracto de la clase 2 gratis</span>
                     </div>
                     <div class="cta-feature">
                         <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">

--- a/fabuladores/styles.css
+++ b/fabuladores/styles.css
@@ -551,6 +551,9 @@ strong {
 /* Hero Visual */
 .hero-visual {
   position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .course-preview-container {
@@ -2267,6 +2270,9 @@ input:checked + .slider:before {
   
   .hero-visual {
     margin-top: var(--spacing-xl);
+    display: flex;
+    justify-content: center;
+    align-items: center;
   }
   
   .course-logo-image {


### PR DESCRIPTION
## Summary
- unlink logo so visitors stay on the page
- update tagline to "Zona de Exploración Narrativa"
- replace all short guarantee text with "Mira un extracto de la clase 2 gratis"
- tweak hero header and CTA copy
- center hero video using flexbox
- remove outdated marketing lines

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686bf513e758832cb951c78fe9629d5a