### PR TITLE
Remove guarantee section from Fabuladores page

### DIFF
--- a/fabuladores/index.html
+++ b/fabuladores/index.html
@@ -989,28 +989,6 @@
         </div>
     </section>
 
-    <!-- Garantía destacada -->
-    <section class="guarantee-section">
-        <div class="container">
-            <div class="guarantee-box">
-                <div class="guarantee-icon">
-                    <svg width="60" height="60" viewBox="0 0 24 24" fill="currentColor">
-                        <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4z"/>
-                    </svg>
-                </div>
-                <div class="guarantee-content">
-                    <h2 class="guarantee-title">Garantía de satisfacción de 30 días</h2>
-                    <p class="guarantee-text">
-                        Si por cualquier razón no estás completamente satisfecho con el curso, 
-                        te devolvemos el 100% de tu dinero. Sin preguntas, sin letra chica.
-                    </p>
-                    <p class="guarantee-subtext">
-                        Tu satisfacción es nuestra prioridad. Queremos que aprendas sin riesgos.
-                    </p>
-                </div>
-            </div>
-        </div>
-    </section>
 
     <!-- FAQ mejorado -->
     <section class="faq" id="preguntas">
@@ -1027,7 +1005,6 @@
                         <p>No, el curso está diseñado tanto para principiantes como para escritores con experiencia. Empezamos desde los fundamentos y avanzamos progresivamente hacia técnicas más complejas. Cada estudiante puede ir a su propio ritmo.</p>
                     </div>
                 </div>
-
                 <div class="faq-item">
                     <button class="faq-question" aria-expanded="false">
                         <span class="faq-icon">+</span>
@@ -1037,7 +1014,6 @@
                         <p>Recomendamos dedicar entre 3-5 horas por semana. Cada clase dura aproximadamente 45-60 minutos, más el tiempo para lecturas y ejercicios. La mayoría completa el curso en 6-8 semanas, pero tienes 3 meses (6 en Plan Ultra) de acceso.</p>
                     </div>
                 </div>
-
                 <div class="faq-item">
                     <button class="faq-question" aria-expanded="false">
                         <span class="faq-icon">+</span>
@@ -1047,7 +1023,6 @@
                         <p>El Plan Ultra incluye ejercicios resueltos paso a paso, acceso a nuestra comunidad privada donde puedes compartir textos y recibir feedback, consultas directas con el instructor, y sesiones grupales mensuales en vivo. Además, tienes 6 meses de acceso en lugar de 3.</p>
                     </div>
                 </div>
-
                 <div class="faq-item">
                     <button class="faq-question" aria-expanded="false">
                         <span class="faq-icon">+</span>
@@ -1075,16 +1050,6 @@
                     </button>
                     <div class="faq-answer">
                         <p>Sí, al completar todas las clases y ejercicios recibirás un certificado digital de Fabuladores que puedes incluir en tu CV o portfolio. El certificado incluye tu nombre, la fecha de finalización y está firmado por el instructor.</p>
-                    </div>
-                </div>
-
-                <div class="faq-item">
-                    <button class="faq-question" aria-expanded="false">
-                        <span class="faq-icon">+</span>
-                        <span class="faq-text">¿Qué pasa si no me gusta el curso?</span>
-                    </button>
-                    <div class="faq-answer">
-                        <p>Ofrecemos una garantía de satisfacción de 30 días. Si por cualquier razón no estás satisfecho, simplemente envíanos un email y te devolvemos el 100% de tu dinero, sin preguntas. Queremos que aprendas sin riesgos.</p>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- remove the money-back guarantee section
- remove FAQ entry about the guarantee

## Testing
- `grep -n "garant" fabuladores/index.html`


------
https://chatgpt.com/codex/tasks/task_e_686cfc8939d4832c95d7e907f75165e4