### PR TITLE
Improve contrast on Fabuladores

### DIFF
--- a/fabuladores/index.html
+++ b/fabuladores/index.html
@@ -73,7 +73,7 @@
   --success-green-dark: #059669;
   --accent-orange: #f59e0b;
   --accent-orange-dark: #d97706;
-  --warning-red: #ef4444;
+  --warning-red: #b91c1c; /* color ajustado para mayor contraste */
   
   /* Colores de texto optimizados para legibilidad */
   --text-dark: #1f2937;
@@ -212,6 +212,7 @@ strong {
   font-size: clamp(2rem, 5vw, 3rem);
   font-weight: 800;
   color: var(--text-dark);
+  text-shadow: 0 1px 2px rgba(0,0,0,0.1);
   text-align: center;
   margin-bottom: var(--spacing-md);
   line-height: 1.2;
@@ -357,7 +358,7 @@ strong {
 
 .btn-discount {
   background: var(--accent-orange);
-  color: white;
+  color: var(--text-dark); /* mejora de contraste */
   padding: 0.25rem 0.625rem;
   border-radius: var(--radius-full);
   font-size: 0.75rem;
@@ -437,6 +438,7 @@ strong {
   font-size: clamp(3rem, 6vw, 4.5rem);
   font-weight: 900;
   color: var(--text-dark);
+  text-shadow: 0 1px 3px rgba(0,0,0,0.15); /* mejora legibilidad */
   line-height: 1.1;
   margin-bottom: var(--spacing-lg);
   animation: fadeInUp 0.8s ease-out;
@@ -4584,7 +4586,7 @@ style.textContent = `
   
   .urgent .countdown-value,
   .urgent .countdown-number {
-    color: #ef4444 !important;
+    color: var(--warning-red) !important;
     animation: urgentPulse 1s infinite;
   }
   


### PR DESCRIPTION
## Summary
- adjust color variables for better accessibility
- refine `.btn-discount` color
- add subtle text-shadow to titles
- use `var(--warning-red)` for countdown urgency

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e1458b914832ca672bd194cfcc281