### PR TITLE
Add digital ad proposal page for Gadal Services

### DIFF
--- a/propuesta-gadal-services.html
+++ b/propuesta-gadal-services.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Propuesta de Publicidad Digital – Gadal Services</title>
+</head>
+<body>
+    <header>
+        <h1>Propuesta de Publicidad Digital – Gadal Services</h1>
+    </header>
+    <section>
+        <h2>Objetivo General</h2>
+        <p>Generar leads calificados (dueños y administradores de clínicas privadas) interesados en los planes de consultoría, a través de canales digitales de alta efectividad, maximizando el ROI con un presupuesto controlado.</p>
+    </section>
+    <section>
+        <h2>1. Propuesta Google Ads (USD 100/mes)</h2>
+        <h3>Estrategia</h3>
+        <ul>
+            <li>Enfoque principal: campañas de búsqueda (Search) para captar a usuarios con intención activa de contratar consultoría en gestión de clínicas.</li>
+            <li>Apoyo secundario: remarketing en Display para mantener presencia frente a visitantes web.</li>
+            <li>Protección de marca: campaña de palabras clave relacionadas a “Gadal Services”.</li>
+        </ul>
+        <h3>Estructura</h3>
+        <ul>
+            <li>70% Presupuesto (USD 70): Campaña Search → keywords de intención alta (“consultoría para clínicas privadas”, “gestión clínica Costa Rica”, etc.).</li>
+            <li>20% (USD 20): Remarketing Display → impactar visitantes que no convirtieron.</li>
+            <li>10% (USD 10): Campaña de Marca → proteger búsquedas de la empresa.</li>
+        </ul>
+        <h3>Resultados esperados</h3>
+        <ul>
+            <li>CTR: &gt; 4%</li>
+            <li>CPC promedio: USD 0,20–0,50</li>
+            <li>Leads estimados: 8–12 mensuales</li>
+            <li>CPL esperado: USD 8–12</li>
+            <li>Con solo 1 cliente nuevo (ticket USD 400–800/mes) → ROI muy positivo.</li>
+        </ul>
+        <p><strong>Ventaja clave:</strong> Google Ads capta a personas que ya buscan activamente soluciones, ideal para un servicio B2B de alto ticket.</p>
+    </section>
+    <section>
+        <h2>2. Propuesta Meta Ads (USD 100/mes)</h2>
+        <h3>Estrategia</h3>
+        <p><em>“El 90% del éxito está en el objetivo correcto + creatividades de alto impacto”.</em></p>
+        <ul>
+            <li>Campaña de Presentación (Frío): 70% presupuesto → intereses en sector salud, lookalikes, segmentación abierta.</li>
+            <li>Campaña de Retargeting (Caliente): 30% → visitantes web, engagers en redes, viewers de videos.</li>
+            <li>Optimización: objetivo exclusivo “Clientes Potenciales” (no tráfico ni engagement).</li>
+        </ul>
+        <h3>Creatividades Premium</h3>
+        <ul>
+            <li>12–15 piezas/mes:</li>
+            <li>Videos testimoniales.</li>
+            <li>Carruseles problema → solución.</li>
+            <li>Animaciones con métricas.</li>
+            <li>Banners de urgencia (ej. “Últimos 5 diagnósticos gratis este mes”).</li>
+            <li>Formatos optimizados: Reels/Stories, Feed, Right Column.</li>
+        </ul>
+        <p><strong>Ventaja clave:</strong> Meta Ads genera visibilidad, construcción de marca y un flujo de leads desde la interrupción/publicidad directa.</p>
+    </section>
+    <section>
+        <h2>Comparación rápida</h2>
+        <table border="1" cellpadding="8" cellspacing="0">
+            <thead>
+                <tr>
+                    <th>Aspecto</th>
+                    <th>Google Ads</th>
+                    <th>Meta Ads</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Tipo de demanda</td>
+                    <td>Captura demanda activa (personas que ya buscan el servicio).</td>
+                    <td>Genera demanda desde awareness (interrupción/publicidad).</td>
+                </tr>
+                <tr>
+                    <td>Adecuación al negocio</td>
+                    <td>Muy alta: ticket alto + B2B consultivo.</td>
+                    <td>Media: útil para visibilidad y remarketing, pero menos eficiente en cierres directos.</td>
+                </tr>
+                <tr>
+                    <td>Inversión mínima efectiva</td>
+                    <td>USD 100/mes (Search precisa).</td>
+                    <td>USD 200–300/mes recomendado para volumen de creatividades.</td>
+                </tr>
+                <tr>
+                    <td>ROI esperado</td>
+                    <td>Alto: 1 cliente cubre la inversión por varios meses.</td>
+                    <td>Medio: requiere tiempo y constancia en creatividades.</td>
+                </tr>
+            </tbody>
+        </table>
+    </section>
+    <section>
+        <h2>Recomendación</h2>
+        <p>Dado el modelo de negocio de Gadal Services (B2B, ticket alto, cliente muy específico), sugerimos iniciar con Google Ads como canal prioritario.</p>
+        <ul>
+            <li>Permite aprovechar el presupuesto reducido (USD 100/mes).</li>
+            <li>Capta directamente a quienes ya tienen la necesidad de ordenar sus clínicas.</li>
+            <li>El ROI es inmediato si se cierra un solo cliente.</li>
+        </ul>
+        <p>Una vez validada la estrategia y generados los primeros clientes, se recomienda sumar Meta Ads como canal de soporte para awareness, remarketing y construcción de marca.</p>
+    </section>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create proposal page for Gadal Services detailing Google Ads and Meta Ads strategies

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a24ac21468832ca4f85e1636a13d3a